### PR TITLE
Changelog generating independently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,15 @@ jobs:
          with:
            token: ${{ secrets.GITHUB_TOKEN }}
            dateFormat: '%m/%d/%Y'
+       - name: Make directory
+         run: mkdir changelog
+       - name: Generate release changelog (Single tag)
+         uses: heinrichreimer/github-changelog-generator-action@6653241a44afb59146f719f322005de49a5c3b38
+         with:
+           token: ${{ secrets.GITHUB_TOKEN }}
+           dateFormat: '%m/%d/%Y'
+           onlyLastTag: true
+           output: /changelog/CHANGELOG.md
        - name: Download normal pack
          uses: actions/download-artifact@076f0f7dd036d87e8e04f5f00d614e790308961b
          with:
@@ -121,7 +130,7 @@ jobs:
          with:
            files: |
              *.zip
-           body_path: CHANGELOG.md
+           body_path: /changelog/CHANGELOG.md
        - name: Commit changes
          run: |
             echo ${GITHUB_REF#refs/*/}
@@ -130,4 +139,3 @@ jobs:
             git add CHANGELOG.md
             git commit -m "[ci skip] Updated CHANGELOG.md for ${{ steps.get_version.outputs.VERSION }}"
             git push origin HEAD:master
-            

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -94,6 +94,15 @@ jobs:
          with:
            token: ${{ secrets.GITHUB_TOKEN }}
            dateFormat: '%m/%d/%Y'
+       - name: Make directory
+         run: mkdir changelog
+       - name: Generate release changelog (Single tag)
+         uses: heinrichreimer/github-changelog-generator-action@6653241a44afb59146f719f322005de49a5c3b38
+         with:
+           token: ${{ secrets.GITHUB_TOKEN }}
+           dateFormat: '%m/%d/%Y'
+           onlyLastTag: true
+           output: /changelog/CHANGELOG.md           
        - name: Download normal pack
          uses: actions/download-artifact@076f0f7dd036d87e8e04f5f00d614e790308961b
          with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Created by https://gitignore.io
+# Created in part by https://gitignore.io
 
 # Created by git for backups
 *.orig
@@ -67,3 +67,6 @@ spyglass.json
 
 # Cache files
 .cache
+
+# Changelog for one tag. This should be ignored as if it is pushed to source it will all break
+changelog/

--- a/.yaml-lint.yml
+++ b/.yaml-lint.yml
@@ -1,0 +1,2 @@
+extends: relaxed
+indentation: {spaces: consistent, indent-sequences: consistent}


### PR DESCRIPTION

<!--
WS Datapack bug fix submission guide
====================================
NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.
NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

WS Datapack is GPL
------------------
By contributing to the WS Datapack, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/osfanbuff63/ws-datapack/blob/master/LICENSE.md

Instructions
------------
If you are submitting a bug fix, please follow the following steps:
1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/osfanbuff63/ws-datapack/issues/new/choose 
2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!
3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.
4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)
-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR fixes an internal issue.

### Details

**Proposed fix:**
Changelogs now generate for the main CHANGELOG.md and a `/changelog/CHANGELOG.md` directory, which in turn is used by the release action. The `changelog/` directory is also ignored by git, as if that file is pushed to GitHub it will break everything.

**Environments tested:**

This can only be tested by pushing a tag to `master` in GitHub Actions, and so the best I have is my VS Code extension for GitHub Workflows.
<!-- Type the OS you have used below. e.g. Ubuntu 22.04, Windows 10 -->
OS: Windows 10
VS Code extension: [cschleiden.vscode-github-actions](https://marketplace.visualstudio.com/items?itemName=cschleiden.vscode-github-actions)

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
~~- [ ] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] Most recent Fabric version (1.XX.Y, 0.XX.Y loader, 0.XX.Y API)
- [ ] Most recent Vanilla versions (1.XX.Y)~~
